### PR TITLE
Change Plugin from OpenDistro to Open Distro

### DIFF
--- a/src/plugin.json
+++ b/src/plugin.json
@@ -1,6 +1,6 @@
 {
   "type": "datasource",
-  "name": "OpenDistro for Elasticsearch",
+  "name": "Open Distro for Elasticsearch",
   "id": "grafana-es-open-distro-datasource",
   "category": "logging",
 


### PR DESCRIPTION
The official name for plugin should be Open Distro for Elasticsearch